### PR TITLE
Add PDF export capabilities to analysis slides

### DIFF
--- a/components/slides/balance_sheet_slide.py
+++ b/components/slides/balance_sheet_slide.py
@@ -11,8 +11,9 @@ class BalanceSheetSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
-        
+
         # CSS 스타일 추가
         self._add_custom_styles()
         
@@ -27,6 +28,8 @@ class BalanceSheetSlide(BaseSlide):
         
         with col2:
             self._render_scale_and_structure()
+
+        self.render_pdf_export_button()
         
     def _add_custom_styles(self):
         """커스텀 CSS 스타일 추가"""
@@ -120,30 +123,52 @@ class BalanceSheetSlide(BaseSlide):
         balance_sheet_data = self.data_loader.get_balance_sheet_data()
         
         col1, col2, col3 = st.columns(3)
+        metrics_rows = []
         
         # 총자산 지표
         with col1:
             st.metric(
-                label="총자산 (2022→2024)", 
+                label="총자산 (2022→2024)",
                 value=f"{balance_sheet_data['총자산'].iloc[-1]}억원",
                 delta=f"{((balance_sheet_data['총자산'].iloc[-1] / balance_sheet_data['총자산'].iloc[0]) - 1) * 100:.1f}%"
             )
+            metrics_rows.append([
+                "총자산",
+                f"{balance_sheet_data['총자산'].iloc[0]} → {balance_sheet_data['총자산'].iloc[-1]}억원",
+                f"{((balance_sheet_data['총자산'].iloc[-1] / balance_sheet_data['총자산'].iloc[0]) - 1) * 100:.1f}%"
+            ])
         
         # 총부채 지표
         with col2:
             st.metric(
-                label="총부채 (2022→2024)", 
+                label="총부채 (2022→2024)",
                 value=f"{balance_sheet_data['총부채'].iloc[-1]}억원",
                 delta=f"{((balance_sheet_data['총부채'].iloc[-1] / balance_sheet_data['총부채'].iloc[0]) - 1) * 100:.1f}%"
             )
+            metrics_rows.append([
+                "총부채",
+                f"{balance_sheet_data['총부채'].iloc[0]} → {balance_sheet_data['총부채'].iloc[-1]}억원",
+                f"{((balance_sheet_data['총부채'].iloc[-1] / balance_sheet_data['총부채'].iloc[0]) - 1) * 100:.1f}%"
+            ])
         
         # 자본총계 지표
         with col3:
             st.metric(
-                label="자본총계 (2022→2024)", 
+                label="자본총계 (2022→2024)",
                 value=f"{balance_sheet_data['자본총계'].iloc[-1]}억원",
                 delta=f"{((balance_sheet_data['자본총계'].iloc[-1] / balance_sheet_data['자본총계'].iloc[0]) - 1) * 100:.1f}%"
             )
+            metrics_rows.append([
+                "자본총계",
+                f"{balance_sheet_data['자본총계'].iloc[0]} → {balance_sheet_data['자본총계'].iloc[-1]}억원",
+                f"{((balance_sheet_data['자본총계'].iloc[-1] / balance_sheet_data['자본총계'].iloc[0]) - 1) * 100:.1f}%"
+            ])
+
+        self.add_table_section(
+            "재무상태표 핵심 지표",
+            metrics_rows,
+            headers=["항목", "금액 추이", "증감률"]
+        )
     
     def _render_balance_sheet_chart(self):
         """재무상태표 차트 렌더링"""
@@ -219,6 +244,10 @@ class BalanceSheetSlide(BaseSlide):
             },
             use_datalabels=True
         )
+        self.add_table_section(
+            "재무상태표 추이",
+            balance_sheet_data[["year", "총자산", "총부채", "자본총계"]]
+        )
     
     def _render_scale_and_structure(self):
         """규모 및 구조 렌더링 - 펜시한 카드 형태로, 직접 컨테이너 사용"""
@@ -235,6 +264,7 @@ class BalanceSheetSlide(BaseSlide):
                 </div>
             </div>
             """, unsafe_allow_html=True)
+            self.add_pdf_section("성장투자·배당 확대 여건", insight_msg.get("content2", ""))
         else:
             st.markdown("""
             <div style="background-color: #fef9c3; border-radius: 10px; padding: 20px; box-shadow: 0 4px 6px rgba(0,0,0,0.05); margin-bottom: 20px; border-left: 5px solid #f59e0b;">
@@ -277,6 +307,13 @@ class BalanceSheetSlide(BaseSlide):
             </div>
         </div>
         """, unsafe_allow_html=True)
+        scale_summary = (
+            f"- 총자산: {start_asset} → {end_asset}억 ({asset_growth:+.1f}%)\n"
+            f"- 자본총계: {start_equity} → {end_equity}억 ({equity_growth:+.1f}%)\n"
+            f"- 총부채 증감률: {debt_growth:+.1f}%\n"
+            f"- 부채비율: {start_debt_ratio:.0f}% → {end_debt_ratio:.0f}%"
+        )
+        self.add_pdf_section("Scale and Structure 요약", scale_summary)
     
     def _render_insight(self):
         """인사이트 렌더링 - 펜시한 카드 형태로"""
@@ -291,6 +328,8 @@ class BalanceSheetSlide(BaseSlide):
                 <div style="font-size: 0.95rem; color: #334155; line-height: 1.6;">{insight_data["content1"]}</div>
             </div>
             """, unsafe_allow_html=True)
+            insight_text = f"{insight_data.get('title', '')}\n{insight_data.get('content1', '')}"
+            self.add_pdf_section("재무상태표 인사이트", insight_text)
         else:
             st.markdown("""
             <div style="background: #f0f9ff; border-radius: 10px; padding: 20px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05); margin-bottom: 20px; border-left: 5px solid #f59e0b;">

--- a/components/slides/base_slide.py
+++ b/components/slides/base_slide.py
@@ -1,4 +1,11 @@
+import textwrap
+from typing import List, Optional
+
+import pandas as pd
 import streamlit as st
+from tabulate import tabulate
+
+import fitz
 
 class BaseSlide:
     """모든 슬라이드의 기본 클래스"""
@@ -6,6 +13,7 @@ class BaseSlide:
     def __init__(self, data_loader, title="슬라이드"):
         self.data_loader = data_loader
         self.title = title
+        self.pdf_sections: List[dict] = []
     
     def get_title(self):
         """슬라이드 제목 반환"""
@@ -14,6 +22,38 @@ class BaseSlide:
     def render_header(self):
         """슬라이드 헤더 렌더링"""
         st.markdown(f'<h2 class="slide-header">{self.title}</h2>', unsafe_allow_html=True)
+
+    def reset_pdf_sections(self):
+        """PDF 섹션 초기화"""
+        self.pdf_sections = []
+
+    def add_pdf_section(self, title: str, content: str, kind: str = "text"):
+        """PDF로 내보낼 섹션 추가"""
+        if not content:
+            return
+        self.pdf_sections.append({
+            "title": title,
+            "content": content,
+            "kind": kind
+        })
+
+    def add_table_section(self, title: str, data, headers: Optional[List[str]] = None):
+        """표 형태의 데이터를 PDF 섹션으로 추가"""
+        if data is None:
+            return
+
+        table_str = ""
+        if isinstance(data, pd.DataFrame):
+            if not data.empty:
+                table_str = tabulate(data, headers="keys", tablefmt="grid", showindex=False)
+        else:
+            if headers is None:
+                table_str = tabulate(data, headers="keys", tablefmt="grid", showindex=False)
+            else:
+                table_str = tabulate(data, headers=headers, tablefmt="grid", showindex=False)
+
+        if table_str:
+            self.add_pdf_section(title, table_str, kind="table")
     
     def render_insight_card(self, title, content):
         """인사이트 카드 렌더링"""
@@ -51,3 +91,79 @@ class BaseSlide:
         """슬라이드 렌더링 - 자식 클래스에서 구현해야 함"""
         self.render_header()
         st.warning("이 슬라이드는 아직 구현되지 않았습니다.")
+
+    def render_pdf_export_button(self, filename: Optional[str] = None):
+        """PDF 다운로드 버튼 렌더링"""
+        if not self.pdf_sections:
+            return
+
+        pdf_bytes = self._create_pdf_document(self.pdf_sections)
+        default_filename = f"{self.title.replace(' ', '_')}.pdf"
+        st.download_button(
+            "📄 PDF로 내보내기",
+            data=pdf_bytes,
+            file_name=filename or default_filename,
+            mime="application/pdf",
+            key=f"download_{self.title.replace(' ', '_')}"
+        )
+
+    def _create_pdf_document(self, sections: List[dict]) -> bytes:
+        """섹션 정보를 기반으로 PDF 생성"""
+        doc = fitz.open()
+        page = doc.new_page()
+        margin = 36
+        y_position = margin
+
+        for section in sections:
+            page, y_position = self._insert_wrapped_text(doc, page, y_position, section["title"], fontsize=14, bold=True)
+            y_position += 4
+
+            if section["kind"] == "table":
+                page, y_position = self._insert_table_text(doc, page, y_position, section["content"])
+            else:
+                page, y_position = self._insert_wrapped_text(doc, page, y_position, section["content"], fontsize=11)
+
+            y_position += 8
+
+        pdf_bytes = doc.tobytes()
+        doc.close()
+        return pdf_bytes
+
+    def _insert_wrapped_text(self, doc, page, y_position, text, fontsize=11, bold=False):
+        """페이지에 줄바꿈 적용된 텍스트 삽입"""
+        if not text:
+            return page, y_position
+
+        margin = 36
+        max_width = page.rect.width - 2 * margin
+        wrap_width = max(int(max_width / (fontsize * 0.55)), 20)
+        fontname = "helv" if not bold else "helv"
+
+        paragraphs = text.split("\n")
+        for paragraph in paragraphs:
+            lines = textwrap.wrap(paragraph, width=wrap_width) or [""]
+            for line in lines:
+                if y_position > page.rect.height - margin:
+                    page = doc.new_page()
+                    y_position = margin
+                page.insert_text((margin, y_position), line, fontsize=fontsize, fontname=fontname)
+                y_position += fontsize + 2
+            y_position += 4
+
+        return page, y_position
+
+    def _insert_table_text(self, doc, page, y_position, table_text):
+        """표 형태의 문자열을 PDF에 삽입"""
+        if not table_text:
+            return page, y_position
+
+        margin = 36
+        fontsize = 9
+        for line in table_text.split("\n"):
+            if y_position > page.rect.height - margin:
+                page = doc.new_page()
+                y_position = margin
+            page.insert_text((margin, y_position), line, fontsize=fontsize, fontname="cour")
+            y_position += fontsize + 2
+
+        return page, y_position

--- a/components/slides/cash_flow_slide.py
+++ b/components/slides/cash_flow_slide.py
@@ -12,8 +12,9 @@ class CashFlowSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
-        
+
         # CSS 스타일 추가
         self._add_custom_styles()
         
@@ -28,6 +29,27 @@ class CashFlowSlide(BaseSlide):
         
         with col2:
             self._render_cash_flow_analysis()
+
+        cash_flow_data = self.data_loader.get_cash_flow_data()
+        if not cash_flow_data.empty:
+            self.add_table_section(
+                "현금흐름 추이",
+                cash_flow_data[["year", "영업활동", "투자활동", "재무활동", "FCF"]]
+            )
+            latest_year = cash_flow_data['year'].iloc[-1]
+            summary_text = (
+                f"- {latest_year}년 영업활동현금흐름: {cash_flow_data['영업활동'].iloc[-1]}억원\n"
+                f"- {latest_year}년 투자활동현금흐름: {cash_flow_data['투자활동'].iloc[-1]}억원\n"
+                f"- {latest_year}년 재무활동현금흐름: {cash_flow_data['재무활동'].iloc[-1]}억원\n"
+                f"- {latest_year}년 잉여현금흐름(FCF): {cash_flow_data['FCF'].iloc[-1]}억원"
+            )
+            self.add_pdf_section("현금흐름 핵심 요약", summary_text)
+
+        insights = self.data_loader.get_insights().get("cash_flow", {})
+        insight_text = insights.get("summary", "현금흐름 관련 인사이트가 제공되지 않았습니다.")
+        self.add_pdf_section("현금흐름 인사이트", insight_text)
+
+        self.render_pdf_export_button()
     
     def _add_custom_styles(self):
         """커스텀 CSS 스타일 추가"""

--- a/components/slides/conclusion_slide.py
+++ b/components/slides/conclusion_slide.py
@@ -13,9 +13,34 @@ class ConclusionSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
         self._render_strengths_weaknesses()
         self._render_strategic_recommendations()
+
+        conclusion_data = self.company_info.get('conclusion', {})
+        strengths = conclusion_data.get('strengths', [])
+        if strengths:
+            strengths_text = "\n".join(
+                [f"- {item.get('title', '')}: {item.get('description', '')}" for item in strengths]
+            )
+            self.add_pdf_section("강점", strengths_text)
+
+        weaknesses = conclusion_data.get('weaknesses', [])
+        if weaknesses:
+            weaknesses_text = "\n".join(
+                [f"- {item.get('title', '')}: {item.get('description', '')}" for item in weaknesses]
+            )
+            self.add_pdf_section("개선 필요사항", weaknesses_text)
+
+        recommendations = conclusion_data.get('strategic_recommendations', [])
+        if recommendations:
+            recommendation_text = "\n".join(
+                [f"- {rec.get('title', '')}: {rec.get('description', '')}" for rec in recommendations]
+            )
+            self.add_pdf_section("전략적 제안", recommendation_text)
+
+        self.render_pdf_export_button()
    
     def _render_strengths_weaknesses(self):
         """강점과 개선 필요사항 렌더링"""

--- a/components/slides/growth_rate_slide.py
+++ b/components/slides/growth_rate_slide.py
@@ -11,11 +11,12 @@ class GrowthRateSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
 
         # CSS 스타일 추가
         self._add_custom_styles()
-        
+
         # 인사이트 데이터 가져오기
         insights = self.data_loader.get_insights()
         growth_insight = insights.get('growth_rates', {})
@@ -89,6 +90,25 @@ class GrowthRateSlide(BaseSlide):
         
         with col2:
             self._render_key_metrics(insight_message)
+
+        growth_rates_df = self.data_loader.get_growth_rates()
+        if not growth_rates_df.empty:
+            self.add_table_section(
+                "성장률 추이",
+                growth_rates_df[["year", "총자산성장률", "매출액성장률", "순이익성장률"]]
+            )
+            latest_year = growth_rates_df['year'].iloc[-1]
+            summary_text = (
+                f"- {latest_year}년 총자산성장률: {growth_rates_df['총자산성장률'].iloc[-1]}%\n"
+                f"- {latest_year}년 매출액성장률: {growth_rates_df['매출액성장률'].iloc[-1]}%\n"
+                f"- {latest_year}년 순이익성장률: {growth_rates_df['순이익성장률'].iloc[-1]}%"
+            )
+            self.add_pdf_section("성장률 핵심 요약", summary_text)
+
+        insight_summary = growth_insight.get('content2', insight_message)
+        self.add_pdf_section("성장성 인사이트", insight_summary)
+
+        self.render_pdf_export_button()
     
     def _add_custom_styles(self):
         """커스텀 CSS 스타일 추가"""

--- a/components/slides/income_statement_slide.py
+++ b/components/slides/income_statement_slide.py
@@ -11,48 +11,73 @@ class IncomeStatementSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
-        
+
         # 차트와 인사이트를 나란히 배치하기 위해 columns 사용
         col1, col2 = st.columns([7, 5])  # 7:5 비율로 열 분할
         with col1:
             self._render_key_metrics()
             self._render_income_statement_chart()
-        
+
         with col2:
             self._render_insight()
+
+        self.render_pdf_export_button()
     
     def _render_key_metrics(self):
         """핵심 지표 렌더링"""
         performance_data = self.data_loader.get_performance_data()
         
         col1, col2, col3 = st.columns(3)
+        metrics_rows = []
         
         # 매출액 지표
         with col1:
             st.metric(
-                label="매출액 (2022→2024)", 
+                label="매출액 (2022→2024)",
                 value=f"{performance_data['매출액'].iloc[-1]}억원",
                 delta=f"{((performance_data['매출액'].iloc[-1] / performance_data['매출액'].iloc[0]) - 1) * 100:.1f}%",
                 delta_color="inverse"
             )
+            metrics_rows.append([
+                "매출액",
+                f"{performance_data['매출액'].iloc[0]} → {performance_data['매출액'].iloc[-1]}억원",
+                f"{((performance_data['매출액'].iloc[-1] / performance_data['매출액'].iloc[0]) - 1) * 100:.1f}%"
+            ])
         
         # 영업이익 지표
         with col2:
             st.metric(
-                label="영업이익 (2022→2024)", 
+                label="영업이익 (2022→2024)",
                 value=f"{performance_data['영업이익'].iloc[-1]}억원",
                 delta=f"{((performance_data['영업이익'].iloc[-1] / performance_data['영업이익'].iloc[0]) - 1) * 100:.1f}%",
                 delta_color="inverse"
             )
+            metrics_rows.append([
+                "영업이익",
+                f"{performance_data['영업이익'].iloc[0]} → {performance_data['영업이익'].iloc[-1]}억원",
+                f"{((performance_data['영업이익'].iloc[-1] / performance_data['영업이익'].iloc[0]) - 1) * 100:.1f}%"
+            ])
         
         # 순이익 지표
         with col3:
             st.metric(
-                label="순이익 (2022→2024)", 
+                label="순이익 (2022→2024)",
                 value=f"{performance_data['순이익'].iloc[-1]}억원",
                 delta=f"{((performance_data['순이익'].iloc[-1] / performance_data['순이익'].iloc[0]) - 1) * 100:.1f}%"
             )
+            metrics_rows.append([
+                "순이익",
+                f"{performance_data['순이익'].iloc[0]} → {performance_data['순이익'].iloc[-1]}억원",
+                f"{((performance_data['순이익'].iloc[-1] / performance_data['순이익'].iloc[0]) - 1) * 100:.1f}%"
+            ])
+
+        self.add_table_section(
+            "핵심 손익 지표 변화",
+            metrics_rows,
+            headers=["항목", "금액 추이", "증감률"]
+        )
     
     def _render_income_statement_chart(self):
         """손익계산서 차트 렌더링"""
@@ -140,6 +165,10 @@ class IncomeStatementSlide(BaseSlide):
             },
             use_datalabels=True  # datalabels 플러그인 사용 설정
         )
+        self.add_table_section(
+            "손익계산서 추이",
+            performance_data[["year", "매출액", "영업이익", "순이익", "순이익률"]]
+        )
     
     def _render_insight(self):
         """인사이트 렌더링"""
@@ -191,3 +220,11 @@ class IncomeStatementSlide(BaseSlide):
             </div>
         </div>
         """, unsafe_allow_html=True)
+        insight_summary = (
+            f"- 매출액 변화: {start_revenue} → {end_revenue}억원 ({revenue_change:.1f}%)\n"
+            f"- 영업이익 변화: {start_op_profit} → {end_op_profit}억원 ({op_profit_change:.1f}%)\n"
+            f"- 순이익 변화: {start_net_profit} → {end_net_profit}억원 ({net_profit_change:.1f}%)\n"
+            f"- 순이익률 변화: {start_net_margin}% → {end_net_margin}%\n"
+            f"- 주요 인사이트: {insight_msg}"
+        )
+        self.add_pdf_section("손익계산서 인사이트", insight_summary)

--- a/components/slides/industry_comparison_slide.py
+++ b/components/slides/industry_comparison_slide.py
@@ -15,8 +15,10 @@ class IndustryComparisonSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
         self._render_radar_chart()
+        self.render_pdf_export_button()
     
     def _render_radar_chart(self):
         """레이더 차트 렌더링"""
@@ -206,3 +208,16 @@ class IndustryComparisonSlide(BaseSlide):
             </p>
         </div>
         """, unsafe_allow_html=True)
+
+        if not radar_data.empty:
+            self.add_table_section("업계 비교 지표", radar_data)
+            comparison_highlight = radar_data.sort_values(by=company_column, ascending=False).iloc[0]
+            highlight_text = (
+                f"- 우수 지표: {comparison_highlight['metric']}\n"
+                f"- {company_name}: {comparison_highlight[company_column]} vs 업계 평균 {comparison_highlight['업계평균']}"
+            )
+            self.add_pdf_section("업계 비교 요약", highlight_text)
+
+        insights = self.data_loader.get_insights().get("industry_comparison", {})
+        insight_text = insights.get("summary", insights.get("content", "업계 비교 인사이트가 제공되지 않았습니다."))
+        self.add_pdf_section("업계 비교 인사이트", insight_text)

--- a/components/slides/profitability_slide.py
+++ b/components/slides/profitability_slide.py
@@ -11,8 +11,9 @@ class ProfitabilitySlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
-        
+
         # CSS 스타일 추가
         self._add_custom_styles()
         
@@ -27,6 +28,27 @@ class ProfitabilitySlide(BaseSlide):
         
         with col2:
             self._render_profitability_structure()
+
+        dupont_data = self.data_loader.get_dupont_data()
+        if not dupont_data.empty:
+            self.add_table_section(
+                "듀폰 분석 지표",
+                dupont_data[["year", "순이익률", "자산회전율", "재무레버리지", "ROE"]]
+            )
+            latest_year = dupont_data['year'].iloc[-1]
+            summary_text = (
+                f"- {latest_year}년 순이익률: {dupont_data['순이익률'].iloc[-1]}%\n"
+                f"- {latest_year}년 자산회전율: {dupont_data['자산회전율'].iloc[-1]}회\n"
+                f"- {latest_year}년 재무레버리지: {dupont_data['재무레버리지'].iloc[-1]}배\n"
+                f"- {latest_year}년 ROE: {dupont_data['ROE'].iloc[-1]}%"
+            )
+            self.add_pdf_section("수익성 핵심 요약", summary_text)
+
+        insights = self.data_loader.get_insights().get("profitability", {})
+        insight_body = insights.get("content", insights.get("summary", "수익성 관련 인사이트가 제공되지 않았습니다."))
+        self.add_pdf_section("수익성 인사이트", insight_body)
+
+        self.render_pdf_export_button()
         
     def _add_custom_styles(self):
         """커스텀 CSS 스타일 추가"""

--- a/components/slides/stability_slide.py
+++ b/components/slides/stability_slide.py
@@ -11,8 +11,9 @@ class StabilitySlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
-        
+
         # CSS 스타일 추가
         self._add_custom_styles()
         
@@ -27,6 +28,26 @@ class StabilitySlide(BaseSlide):
         
         with col2:
             self._render_stability_structure()
+
+        stability_data = self.data_loader.get_stability_data()
+        if not stability_data.empty:
+            self.add_table_section(
+                "안정성 지표 추이",
+                stability_data[["year", "부채비율", "유동비율", "이자보상배율"]]
+            )
+            latest_year = stability_data['year'].iloc[-1]
+            summary_text = (
+                f"- {latest_year}년 부채비율: {stability_data['부채비율'].iloc[-1]}%\n"
+                f"- {latest_year}년 유동비율: {stability_data['유동비율'].iloc[-1]}%\n"
+                f"- {latest_year}년 이자보상배율: {stability_data['이자보상배율'].iloc[-1]}배"
+            )
+            self.add_pdf_section("안정성 핵심 요약", summary_text)
+
+        insights = self.data_loader.get_insights().get("stability", {})
+        insight_text = insights.get("summary", insights.get("content", "안정성 관련 인사이트가 제공되지 않았습니다."))
+        self.add_pdf_section("안정성 인사이트", insight_text)
+
+        self.render_pdf_export_button()
     
     def _add_custom_styles(self):
         """커스텀 CSS 스타일 추가"""

--- a/components/slides/summary_slide.py
+++ b/components/slides/summary_slide.py
@@ -14,9 +14,11 @@ class SummarySlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
         self._render_key_metrics()
         self._render_highlights()
+        self.render_pdf_export_button()
     
     def _render_key_metrics(self):
         """핵심 지표 렌더링"""
@@ -61,6 +63,8 @@ class SummarySlide(BaseSlide):
             <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 1rem;">
         """
 
+        table_rows = []
+
         # 수익성 지표
         metrics = [
             {
@@ -100,6 +104,11 @@ class SummarySlide(BaseSlide):
                     </div>
                 </div>
             """
+            table_rows.append([
+                metric['label'],
+                metric['value'],
+                metric['delta'] + " (전년비)"
+            ])
 
         # 안정성 지표
         metrics = [
@@ -140,6 +149,11 @@ class SummarySlide(BaseSlide):
                     </div>
                 </div>
             """
+            table_rows.append([
+                metric['label'],
+                metric['value'],
+                metric['delta'] + " (전년비)"
+            ])
 
         html_content += """
             </div>
@@ -147,6 +161,11 @@ class SummarySlide(BaseSlide):
         """
         
         components.html(html_content, height=400, scrolling=False)
+        self.add_table_section(
+            "핵심 재무 지표 (2024년)",
+            table_rows,
+            headers=["지표", "값", "전년 대비"]
+        )
 
     def _render_highlights(self):
         """주요 하이라이트 렌더링"""
@@ -154,6 +173,7 @@ class SummarySlide(BaseSlide):
         profitability_data = self.data_loader.get_profitability_data()
         stability_data = self.data_loader.get_stability_data()
         growth_rates = self.data_loader.get_growth_rates()
+        insights = self.data_loader.get_insights()
         
         # 주요 특징 계산
         revenue_growth = growth_rates['매출액성장률'].iloc[-1]
@@ -301,3 +321,13 @@ class SummarySlide(BaseSlide):
         """
         
         components.html(html_content, height=500, scrolling=False)
+        summary_message = insights.get('summary', {}).get('key_highlight', '요약 메시지가 제공되지 않았습니다.')
+        highlights_text = (
+            f"- 매출 성장률: {revenue_growth:.1f}%\n"
+            f"- 순이익 성장률: {profit_growth:.1f}%\n"
+            f"- 순이익률: {profit_margin:.1f}%\n"
+            f"- ROE: {roe:.1f}%\n"
+            f"- 부채비율: {debt_ratio:.1f}%\n"
+            f"- 주요 메시지: {summary_message}"
+        )
+        self.add_pdf_section("재무 하이라이트", highlights_text)

--- a/components/slides/valuation_manual_slide.py
+++ b/components/slides/valuation_manual_slide.py
@@ -25,8 +25,9 @@ class ValuationManualSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
-        
+
         # CSS 스타일 추가
         self._add_custom_styles()
         
@@ -43,9 +44,15 @@ class ValuationManualSlide(BaseSlide):
         if "valuation_results" not in st.session_state:
             # 가치 평가 시작 폼
             self._render_valuation_form()
+            self.add_pdf_section(
+                "가치평가 안내",
+                "가치평가 파라미터를 입력하고 평가를 실행하면 결과를 확인하고 PDF로 저장할 수 있습니다."
+            )
         else:
             # 가치 평가 결과 표시
             self._render_valuation_results()
+
+        self.render_pdf_export_button()
     
     def _add_custom_styles(self):
         """커스텀 CSS 스타일 추가"""
@@ -1400,12 +1407,24 @@ class ValuationManualSlide(BaseSlide):
         """가치평가 결과 표시"""
         company_name = self.company_data.get('company_name', '기업')
         valuation_results = st.session_state.valuation_results
-        
+
         method = valuation_results.get("method", "알 수 없음")
-        
+
         # 결과 헤더 표시
         st.markdown(f"## {company_name} 가치평가 결과 - {method}")
-        
+
+        summary_lines = []
+        for key, value in valuation_results.items():
+            if isinstance(value, dict):
+                summary_lines.append(f"{key}:")
+                for sub_key, sub_value in value.items():
+                    summary_lines.append(f"  - {sub_key}: {sub_value}")
+            else:
+                summary_lines.append(f"{key}: {value}")
+
+        if summary_lines:
+            self.add_pdf_section("수동 가치평가 요약", "\n".join(summary_lines))
+
         # 결과 요약 표시
         self._render_valuation_summary(valuation_results)
         

--- a/components/slides/valuation_slide.py
+++ b/components/slides/valuation_slide.py
@@ -16,18 +16,25 @@ class ValuationSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
-        
+
         # CSS 스타일 추가
         self._add_custom_styles()
-        
+
         # 세션 상태에 가치 평가 결과가 있는지 확인
         if "valuation_data" not in st.session_state:
             # 가치 평가 시작 버튼
             self._render_valuation_request_form()
+            self.add_pdf_section(
+                "가치 평가 안내",
+                "AI 기반 가치 평가를 실행하려면 'AI 기업 가치 평가 시작' 버튼을 클릭하세요."
+            )
         else:
             # 가치 평가 결과 표시
             self._render_valuation_results()
+
+        self.render_pdf_export_button()
     
     def _add_custom_styles(self):
         """커스텀 CSS 스타일 추가"""
@@ -279,7 +286,19 @@ class ValuationSlide(BaseSlide):
         if valuation_data:
             # 가치 평가 결과 표시
             display_valuation_results(valuation_data)
-            
+
+            summary_lines = []
+            for key, value in valuation_data.items():
+                if isinstance(value, dict):
+                    summary_lines.append(f"{key}:")
+                    for sub_key, sub_value in value.items():
+                        summary_lines.append(f"  - {sub_key}: {sub_value}")
+                else:
+                    summary_lines.append(f"{key}: {value}")
+
+            if summary_lines:
+                self.add_pdf_section("가치 평가 결과 요약", "\n".join(summary_lines))
+
             # 결과 다운로드 버튼 - 고급 UI로 표시
             company_name = valuation_data.get("company", "company")
             

--- a/components/slides/working_capital_slide.py
+++ b/components/slides/working_capital_slide.py
@@ -11,8 +11,9 @@ class WorkingCapitalSlide(BaseSlide):
     
     def render(self):
         """슬라이드 렌더링"""
+        self.reset_pdf_sections()
         self.render_header()
-        
+
         # CSS 스타일 추가
         self._add_custom_styles()
         
@@ -27,6 +28,27 @@ class WorkingCapitalSlide(BaseSlide):
         
         with col2:
             self._render_working_capital_analysis()
+
+        working_capital_data = self.data_loader.get_working_capital_data()
+        if not working_capital_data.empty:
+            self.add_table_section(
+                "운전자본 지표 추이",
+                working_capital_data[["year", "CCC", "DSO", "DIO", "DPO"]]
+            )
+            latest_year = working_capital_data['year'].iloc[-1]
+            summary_text = (
+                f"- {latest_year}년 현금전환주기: {working_capital_data['CCC'].iloc[-1]}일\n"
+                f"- {latest_year}년 매출채권회수기간: {working_capital_data['DSO'].iloc[-1]}일\n"
+                f"- {latest_year}년 재고자산보유기간: {working_capital_data['DIO'].iloc[-1]}일\n"
+                f"- {latest_year}년 매입채무결제기간: {working_capital_data['DPO'].iloc[-1]}일"
+            )
+            self.add_pdf_section("운전자본 핵심 요약", summary_text)
+
+        insights = self.data_loader.get_insights().get("working_capital", {})
+        insight_text = insights.get("summary", insights.get("content", "운전자본 관련 인사이트가 제공되지 않았습니다."))
+        self.add_pdf_section("운전자본 인사이트", insight_text)
+
+        self.render_pdf_export_button()
     
     def _add_custom_styles(self):
         """커스텀 CSS 스타일 추가"""


### PR DESCRIPTION
## Summary
- add PDF section management and generation utilities to the shared BaseSlide so slides can build exportable documents
- update each financial analysis slide to capture key tables and insights before rendering a PDF download button for the current view

## Testing
- python -m compileall components/slides

------
https://chatgpt.com/codex/tasks/task_e_68dbdd27063c832a94fa715c9f1a9979